### PR TITLE
Add function for computing Antoine coeffs of a mixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,5 @@ jobs:
           python-version: '3.11'
       - run: |
           python -m pip install --upgrade pip
-          pip install numpy pandas
+          pip install numpy pandas scipy
       - run: python test_accuracy.py

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install sphinx sphinx_rtd_theme myst_parser sphinxcontrib-bibtex pandas
+          pip install sphinx sphinx_rtd_theme myst_parser sphinxcontrib-bibtex pandas scipy
 
       - name: Build docs
         run: |

--- a/GroupContributionMethod.py
+++ b/GroupContributionMethod.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+from scipy.optimize import curve_fit
 import os
 
 
@@ -652,6 +653,50 @@ class groupContribution:
 
         return p_v
 
+    def mixture_vapor_pressure_antoine_coeffs(
+        self, mass, Trange, units="mks", correlation="Lee-Kesler"
+    ):
+        """
+        Estimate Antoine coefficients for vapor pressure of the mixture.
+
+        :param mass: Mass of each compound in the mixture.
+        :type mass: np.ndarray
+        :param Trange: Temperature range for fit in Kelvin.
+        :type Trange: np.ndarray (2,)
+        :param units: Units for pressure in fit
+        :type correlation: str, optional
+        :param correlation: Correlation method ("Ambrose-Walton" or "Lee-Kesler").
+        :type correlation: str, optional
+        :return: Coefficients A, B, C, D
+        :rtype: float
+        """
+
+        # Lower and upper temperature limits
+        Tmin = Trange[0]
+        Tmax = Trange[1]
+
+        # Antoine equation log10(p) = A - B/(C + T)
+        def antoine_eq(T, A, B, C):
+            return A - B / (T + C)
+
+        # Determine conversion factor for pressure in MKS, CGS or bar
+        D = 1  # default is Pa
+        if units.lower() == "bar":
+            D = 1e5
+        elif units.lower() == "cgs":
+            D = 10  # dyne/cm^2
+
+        T = np.linspace(Tmin, Tmax, 20)
+        Pvals = np.zeros_like(T)
+        for k in range(len(T)):
+            Pvals[k] = self.mixture_vapor_pressure(mass, T[k]) * D
+
+        logP = np.log10(Pvals)
+        popt, _ = curve_fit(antoine_eq, T, logP, p0=[1, 1e3, -1])  # initial guess
+        A, B, C = popt
+
+        return A, B, C, D
+
     def mixture_surface_tension(self, mass, T, correlation="Brock-Bird"):
         """
         Calculate surface tension of the mixture.
@@ -675,7 +720,7 @@ class groupContribution:
         sti = self.surface_tension(T, correlation)
 
         # Mixture surface tension via arithmetic mean, Poling (12-5.2)
-        st = mixingRule(sti, Xi, "arithmetic")
+        st = mixing_rule(sti, Xi, "arithmetic")
 
         return st
 
@@ -722,7 +767,7 @@ def K2C(T):
     return T - 273.15
 
 
-def mixingRule(var_n, X, pseudo_prop="arithmetic"):
+def mixing_rule(var_n, X, pseudo_prop="arithmetic"):
     """
     Mixing rules for computing mixture properties.
 
@@ -747,3 +792,38 @@ def mixingRule(var_n, X, pseudo_prop="arithmetic"):
                 var_ij = (var_n[i] + var_n[j]) / 2
             var_mix += X[i] * X[j] * var_ij
     return var_mix
+
+
+def droplet_volume(r):
+    """
+    Calculate spherical volume of a droplet given the radius.
+
+    :param r: Radius of the droplet in meters.
+    :type r: float
+    :return: Spherical volume of droplet in cubic meters.
+    :rtype: float
+    """
+    return 4.0 / 3.0 * np.pi * r**3
+
+
+def drop_mass(fuel, r, Yi, T):
+    """
+    Calculate the mass of each compound in the fuel provided the radius of the droplet.
+
+    :param fuel: An instance of the groupContribution class.
+    :type fuel: groupContribution object
+    :param r: Radius of the droplet in meters.
+    :type r: float
+    :param Yi: Mass fractions of each compound.
+    :type Yi: np.ndarray
+    :param T: Droplet temperature in Kelvin.
+    :type T: float
+    :return: Mass of each compound in droplet in kg.
+    :rtype: np.ndarray
+    """
+    MW = fuel.MW  # kg/mol
+    volume = droplet_volume(r)  # m^3
+    if volume > 0:
+        return volume / (fuel.molar_liquid_vol(T) @ Yi) * Yi * fuel.MW
+    else:
+        return np.zeros_like(MW)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ FuelLib (SWR-25-26) utilizes the tables and functions of the Group Contribution 
 ## Python Environment
 The following conda environment is required to run this code:
 ~~~
-conda create --name fuellib-env matplotlib pandas black 
+conda create --name fuellib-env matplotlib pandas scipy black 
 ~~~
 
 ## Running the code
@@ -24,7 +24,7 @@ New contributions are always welcome.  If you have an idea for a new feature fol
 ## Sphinx Documentation
 This repository uses [Sphinx](https://www.sphinx-doc.org/en/master/usage/quickstart.html) to generate documentation.  This requires the following Conda environment:
 ~~~
-conda create --name sphinx-env sphinx sphinx_rtd_theme sphinxcontrib-bibtex pandas
+conda create --name sphinx-env sphinx sphinx_rtd_theme sphinxcontrib-bibtex pandas scipy
 ~~~
 
 To view the documentation locally, build the html using the following: 

--- a/docs/generated/GroupContributionMethod.rst
+++ b/docs/generated/GroupContributionMethod.rst
@@ -15,7 +15,9 @@
    
       C2K
       K2C
-      mixingRule
+      drop_mass
+      droplet_volume
+      mixing_rule
    
    
 

--- a/docs/groupcontribution.rst
+++ b/docs/groupcontribution.rst
@@ -471,7 +471,7 @@ the mixture vapor pressure calculated from Raoult's law above.  Antoine's equati
 
 where :math:`D` is a conversion factor for converting :math:`p_v` to units of bar or dyne/cm :sup:`2` from Pa.
 This feature was added to provide `Pele <https://amrex-combustion.github.io>`_ users an option for estimating these coefficients for use in CFD
-simulations with spray. See the `PelePhysics documentaion <https://amrex-combustion.github.io/PelePhysics/Spray.html>`_
+simulations with spray. See the `PelePhysics documentation <https://amrex-combustion.github.io/PelePhysics/Spray.html>`_
 for additional information. 
 
 

--- a/docs/groupcontribution.rst
+++ b/docs/groupcontribution.rst
@@ -384,11 +384,11 @@ are used throughout this section.
 Conventional mixing rules
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autofunction:: GroupContributionMethod.mixingRule
+.. autofunction:: GroupContributionMethod.mixing_rule
    :noindex:
 
 While many of the mixture properties in FuelLib have a unique mixing rule,
-FuelLib's *mixingRule* function provides a general mixing rule based on the suggestions
+FuelLib's *mixing_rule* function provides a general mixing rule based on the suggestions
 of Harstad et al\ :footcite:p:`harstad_efficient_1997`. For a given property :math:`Q`
 
 .. math::
@@ -457,6 +457,23 @@ The vapor pressure of the mixture is calculated according to Raoult's law:
    \begin{align*}
    p_{v} = \sum_{i = 1}^{N_c} X_i \, p_{\textit{sat},i}.
    \end{align*}
+
+.. automethod:: GroupContributionMethod.groupContribution.mixture_vapor_pressure_antoine_coeffs
+   :noindex:
+
+Users also have the option to return the coefficients from an Antoine fit based on 
+the mixture vapor pressure calculated from Raoult's law above.  Antoine's equation is:
+
+.. math:: 
+   \begin{align*}
+   \log_{10}(D \cdot p_{v}) = A - \frac{B}{C + T},
+   \end{align*}
+
+where :math:`D` is a conversion factor for converting :math:`p_v` to units of bar or dyne/cm :sup:`2` from Pa.
+This feature was added to provide `Pele <https://amrex-combustion.github.io>`_ users an option for estimating these coefficients for use in CFD
+simulations with spray. See the `PelePhysics documentaion <https://amrex-combustion.github.io/PelePhysics/Spray.html>`_
+for additional information. 
+
 
 Mixture surface tension
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/ex_mixtureProperties.py
+++ b/ex_mixtureProperties.py
@@ -32,11 +32,6 @@ marker_size = 75
 drop = {}
 drop["d_0"] = 100 * 1e-6  # initial droplet diameter (m), note: size doesn't matter
 drop["r_0"] = drop["d_0"] / 2.0  # initial droplet radius (m)
-drop["V_0"] = 4.0 / 3.0 * np.pi * drop["r_0"] ** 3  # initial droplet volume
-
-
-def drop_mass(fuel, Yi, T):
-    return drop["V_0"] / (fuel.molar_liquid_vol(T) @ Yi) * Yi * fuel.MW  # (kg)
 
 
 # Line specifications for plotting
@@ -118,7 +113,7 @@ def getPredAndData(fuel_name, prop_name):
     if prop_name == "VaporPressure":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             # Mixture vapor pressure (returns pv in Pa)
             pred[i] = fuel.mixture_vapor_pressure(mass, T_pred[i])
             # Convert vapor pressure to kPa
@@ -127,7 +122,7 @@ def getPredAndData(fuel_name, prop_name):
     if prop_name == "Viscosity":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             pred[i] = fuel.mixture_kinematic_viscosity(mass, T_pred[i])
             # Convert viscosity to mm^2/s
             pred[i] *= 1.0e06
@@ -135,13 +130,13 @@ def getPredAndData(fuel_name, prop_name):
     if prop_name == "SurfaceTension":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             pred[i] = fuel.mixture_surface_tension(mass, T_pred[i])
 
     if prop_name == "ThermalConductivity":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             pred[i] = fuel.mixture_thermal_conductivity(mass, T_pred[i])
 
     return T_data, prop_data, T_pred, pred

--- a/test_accuracy.py
+++ b/test_accuracy.py
@@ -41,7 +41,6 @@ class CompTestCase(unittest.TestCase):
             100 * 1e-6
         )  # initial droplet diameter (m), note: size doesn't matter
         drop["r_0"] = drop["d_0"] / 2.0  # initial droplet radius (m)
-        drop["V_0"] = 4.0 / 3.0 * np.pi * drop["r_0"] ** 3  # initial droplet volume
 
         # Compare to NIST predictions and previous model predictions
         for fuel_name in fuel_names:

--- a/test_functions.py
+++ b/test_functions.py
@@ -4,10 +4,6 @@ import pandas as pd
 import GroupContributionMethod as gcm
 
 
-def drop_mass(drop, fuel, Yi, T):
-    return drop["V_0"] / (fuel.molar_liquid_vol(T) @ Yi) * Yi * fuel.MW  # (kg)
-
-
 def getPredAndData(drop, fuel_name, prop_name):
     # Get the fuel properties based on the GCM
     fuel = gcm.groupContribution(fuel_name)
@@ -38,7 +34,7 @@ def getPredAndData(drop, fuel_name, prop_name):
     if prop_name == "VaporPressure":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(drop, fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             # Mixture vapor pressure (returns pv in Pa)
             pred[i] = fuel.mixture_vapor_pressure(mass, T_pred[i])
             # Convert vapor pressure to kPa
@@ -47,7 +43,7 @@ def getPredAndData(drop, fuel_name, prop_name):
     if prop_name == "Viscosity":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(drop, fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             pred[i] = fuel.mixture_kinematic_viscosity(mass, T_pred[i])
             # Convert viscosity to mm^2/s
             pred[i] *= 1.0e06
@@ -55,13 +51,13 @@ def getPredAndData(drop, fuel_name, prop_name):
     if prop_name == "SurfaceTension":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(drop, fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             pred[i] = fuel.mixture_surface_tension(mass, T_pred[i])
 
     if prop_name == "ThermalConductivity":
         for i in range(0, len(T_pred)):
             # Mass of the droplet at current temp
-            mass = drop_mass(drop, fuel, Y_li, T_pred[i])
+            mass = gcm.drop_mass(fuel, drop["r_0"], Y_li, T_pred[i])
             pred[i] = fuel.mixture_thermal_conductivity(mass, T_pred[i])
 
     return T_data, prop_data, pred


### PR DESCRIPTION
Add function that returns Antoine coefficients for saturated vapor pressure:
$\log_{10}(D \cdot p_v) = A - \frac{B}{C + T}.$ Example below is for JP-8, which provided Antoine coeffs: 15.05077 2429.30991 34.21655 1.0e+05.

![AntoineFit](https://github.com/user-attachments/assets/db210086-1df8-49a9-a5ab-243e701d8b3f)


