### PR TITLE
Add source directory, rename groupContribution class to fuel

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../source"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/fuelprops.rst
+++ b/docs/fuelprops.rst
@@ -1,8 +1,7 @@
-Properties and Model Equations
+Fuel Property Prediction Model
 ==============================
 
-The **Fuel Library** for advanced research on evaporation **(FuelLib)** utilizes
-the group contribution method (GCM), as developed by Constantinou and 
+**FuelLib** utilizes the group contribution method (GCM), as developed by Constantinou and 
 Gani\ :footcite:p:`constantinou_new_1994` \ :footcite:p:`constantinou_estimation_1995` in the mid-1990s, 
 to provide a systematic approach for estimating the thermodynamic properties of
 pure organic compounds. The GCM decomposes molecules into structural groups, 
@@ -143,7 +142,7 @@ provided :math:`T` in K unless noted otherwise.
 Kinematic viscosity
 ^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.viscosity_kinematic
+.. automethod:: FuelLib.fuel.viscosity_kinematic
    :noindex:
 
 The kinematic viscosity of the *i-th* compound of the fuel, 
@@ -166,7 +165,7 @@ Liquids\ :footcite:p:`viswanath_viscosity_2007`) provided :math:`T` in :math:`^{
 Latent heat of vaporization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.latent_heat_vaporization
+.. automethod:: FuelLib.fuel.latent_heat_vaporization
    :noindex:
 
 The latent heat of vaporization for each compound at standard pressure and 
@@ -185,7 +184,7 @@ temperature\ :footcite:p:`govindaraju_group_2016`:
 Liquid molar volume
 ^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.molar_liquid_vol
+.. automethod:: FuelLib.fuel.molar_liquid_vol
    :noindex:
 
 The liquid molar volume is calculated at a specific temperature :math:`T` using 
@@ -211,7 +210,7 @@ where
 Density
 ^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.density
+.. automethod:: FuelLib.fuel.density
    :noindex:
 
 The density of the *i-th* compound is given by
@@ -223,7 +222,7 @@ The density of the *i-th* compound is given by
 Liquid specific heat capacity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.Cl
+.. automethod:: FuelLib.fuel.Cl
    :noindex:
 
 The liquid specific heat capacity for each compound at standard pressure temperature is calculated from the specific heat capacity as:
@@ -236,7 +235,7 @@ The liquid specific heat capacity for each compound at standard pressure tempera
 Saturated vapor pressure
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.psat
+.. automethod:: FuelLib.fuel.psat
    :noindex:
 
 The saturated vapor pressure for each compound is calculated as a function of 
@@ -275,7 +274,7 @@ with :math:`\tau_i = 1 - T_{r,i}`.
 Surface tension
 ^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.surface_tension
+.. automethod:: FuelLib.fuel.surface_tension
    :noindex:
 
 Surface tension for each compound is approximated using the relation:
@@ -298,7 +297,7 @@ or by Curl and Pitzer\ :footcite:p:`poling_properties_2001` \ :footcite:p:`curl_
 Thermal conductivity
 ^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.thermal_conductivity
+.. automethod:: FuelLib.fuel.thermal_conductivity
    :noindex:
 
 Thermal conductivity for each compound is computed according to the method of 
@@ -411,7 +410,7 @@ where :math:`Q_i` is the property of the *i-th* compound of the multicomponent m
 Mixture density
 ^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.mixture_density
+.. automethod:: FuelLib.fuel.mixture_density
    :noindex:
 
 The mixture's density is calculated as:
@@ -424,7 +423,7 @@ The mixture's density is calculated as:
 Mixture kinematic viscosity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.mixture_kinematic_viscosity
+.. automethod:: FuelLib.fuel.mixture_kinematic_viscosity
    :noindex:
 
 The kinematic viscosity of the mixture is computed using the Kendall-Monroe\ :footcite:p:`kendall_viscosity_1917` 
@@ -449,7 +448,7 @@ The Arrhenius rule is:
 Mixture vapor pressure
 ^^^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.mixture_vapor_pressure
+.. automethod:: FuelLib.fuel.mixture_vapor_pressure
    :noindex:
 
 The vapor pressure of the mixture is calculated according to Raoult's law:
@@ -459,7 +458,7 @@ The vapor pressure of the mixture is calculated according to Raoult's law:
    p_{v} = \sum_{i = 1}^{N_c} X_i \, p_{\textit{sat},i}.
    \end{align*}
 
-.. automethod:: FuelLib.groupContribution.mixture_vapor_pressure_antoine_coeffs
+.. automethod:: FuelLib.fuel.mixture_vapor_pressure_antoine_coeffs
    :noindex:
 
 Users also have the option to return the coefficients from an Antoine fit based on 
@@ -479,7 +478,7 @@ for additional information.
 Mixture surface tension
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.mixture_surface_tension
+.. automethod:: FuelLib.fuel.mixture_surface_tension
    :noindex:
 
 The surface tension of the mixture is calculated using the :ref:`conventional-mixing-rules`
@@ -492,7 +491,7 @@ Hugill and van Welsenes\ :footcite:p:`hugill_surface_1986`:
 Mixture thermal conductivity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automethod:: FuelLib.groupContribution.mixture_thermal_conductivity
+.. automethod:: FuelLib.fuel.mixture_thermal_conductivity
    :noindex:
 
 The thermal conductivity of the mixture is calculated using the power law method of 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ If you use FuelLib in your research, please cite the following software record:
    :includehidden:
    :caption: Contents:
 
-   groupcontribution
+   fuelprops
    sourcecode
    tutorials
 

--- a/docs/sourcecode.rst
+++ b/docs/sourcecode.rst
@@ -9,27 +9,32 @@ FuelLib File Organization
 -------------------------
 
 - **docs:** directory containing the documentation source files
+- **fuelData:** 
+    - **gcData:** directory containing a collection of GCxGC compositional data by weight percentages
+    - **groupDecompositionData:** directory containing a collection of functional group decompositions
+    - **propertiesData:** directory containing measurement or predicted data for validation (see *fuelData/dataReferences.md*)
+- **gcmTableData:** directory that contains the pre-tabulated group contributions
+- **source:** directory containing the main source code files
+
+    - ``Export4Converge.py``: script that exports mixture properties over a range of user specified temperatures for use in Converge simulations.
+    - ``Export4Pele.py``: script that exports critical properties and initial mass fraction data for use in Pele simulations.
+    - ``FuelLib.py``: class for enabling GCM predictions
+
+- **tests:**  directory containing CI unit tests for FuelLib. The CI test checks if the cumulative error of property predictions of a new proposed model are less than or equal to the current model.
+    
+    - **baselinePredictions:** directory that contains baseline predictions
+    - ``test_accuracy.py``: unit test used in CI for verifying new model predictions preserve accuracy
+    - ``test_baseline.py``: generates .csv files for the baseline model predictions, which are stored in **baselinePredictions**
+    - ``test_functions.py``: collection of functions used by ``test_baseline.py`` and ``test_accuracy.py``.
+
 - **tutorials:** directory containing example scripts that demonstrate how to use FuelLib
 
     - ``basic.py``: example script that demonstrates basic usage of FuelLib
     - ``compositionPlots.py``: example script that generates composition plots for a given fuel
     - ``hefaBlends.py``: example script that calculates properties of HEFA:Jet-A blends
     - ``mixtureProperties.py``: validation script that calculates properties of single component fuels and mixture properties of multicomponent fuels.
-- ``Export4Converge.py``: script that exports mixture properties over a range of user specified temperatures for use in Converge simulations.
-- ``Export4Pele.py``: script that exports critical properties and initial mass fraction data for use in Pele simulations.
-- **fuelData:** 
-    - **gcData:** directory containing a collection of GCxGC compositional data by weight percentages
-    - **groupDecompositionData:** directory containing a collection of functional group decompositions
-    - **propertiesData:** directory containing measurement or predicted data for validation (see *fuelData/dataReferences.md*)
-- **gcmTableData:** directory that contains the pre-tabulated group contributions
-- ``FuelLib.py``: class for enabling GCM predictions
-- **tests:**  directory containing CI unit tests for FuelLib. The CI test checks if the cumulative error of property predictions of a new proposed model are less than or equal to the current model.
-    
-    - **baselinePredictions:** directory that contains baseline predictions
-    - ``test_accuracy.py``: unit test used in CI for verifying new model predictions preserve accuracy
-    - ``test_baseline.py``: generates .csv files for the baseline model predictions, which are stored in **baselinePredictions**
-    - ``test_functions.py``: collection of functions used by ``test_baseline.py`` and ``test_accuracy.py``.   
 
+- ``paths.py``: file that defines paths to various directories and files used in FuelLib
 
 Source Code Auto-Documentation
 ------------------------------

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -15,9 +15,9 @@ Create and activate a Conda environment, install the required dependencies: ::
     conda create --name fuellib-env matplotlib pandas scipy
     conda activate fuellib-env
 
-Change to the FuelLib directory: ::
+Change to the FuelLib/tutorials directory: ::
 
-    cd FuelLib
+    cd FuelLib/tutorials
 
 Required Input files
 ^^^^^^^^^^^^^^^^^^^^^
@@ -43,17 +43,17 @@ as ``basic.py``. To begin, we will import the necessary modules and create a ``g
 
     import os
     import sys
-    import numpy as np
 
     # Add the FuelLib directory to the Python path
-    fuellib_dir = os.path.dirname(os.path.dirname(__file__))
-    sys.path.append(fuellib_dir)
+    FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+    sys.path.append(FUELLIB_DIR)
+    import paths
     import FuelLib as fl
 
-    # Create a groupContribution object for the fuel "heptane-decane"
-    fuel = fl.groupContribution("heptane-decane")
+    # Create a fuel object for the fuel "heptane-decane"
+    fuel = fl.fuel("heptane-decane")
 
-Upon initialization, the ``groupContribution`` object will read the initial weight 
+Upon initialization, the ``fuel`` object will read the initial weight 
 percentage composition and group decomposition data from the specified files. The object stores
 vectors of the calculated fundamental properties at standard conditions for each component of the fuel as described in :ref:`eq-GCM-properties`. 
 For example, we can display the fuel name, the components in the fuel, the initial composition, and the critical temperature for each component: 
@@ -68,10 +68,10 @@ For example, we can display the fuel name, the components in the fuel, the initi
 
 .. code-block:: none
 
-    Fuel name: heptane-decane
-    Fuel components: ['NC7H16', 'NC10H22']
-    Initial composition: [0.7375 0.2625]
-    Critical temperature: [549.85598051 623.69051582] K
+    >> Fuel name: heptane-decane
+    >> Fuel components: ['NC7H16', 'NC10H22']
+    >> Initial composition: [0.7375 0.2625]
+    >> Critical temperature: [549.85598051 623.69051582] K
 
 Next, we can calculate any of the component- or mixture-level properties using the 
 ``groupContribution`` object. For example, we can calculate the saturated vapor pressure
@@ -88,8 +88,8 @@ for each component and the mixture at a given temperature:
 
 .. code-block:: none
 
-    Saturated vapor pressure at 320 K: [13735.84605413   673.28876023] Pa
-    Mixture saturated vapor pressure at 320 K: 11117.84926875165 Pa
+    >> Saturated vapor pressure at 320 K: [13735.84605413   673.28876023] Pa
+    >> Mixture saturated vapor pressure at 320 K: 11117.84926875165 Pa
 
 The following links provide more information on the :ref:`eq-GCM-correlations` and
 the :ref:`eq-mixture-properties` that can be calculated using the ``groupContribution`` object.
@@ -133,10 +133,19 @@ Default Options
     
 From the ``FuelLib`` directory, run the following command in the terminal, noting that ``--fuel_name`` is the only required input: ::
     
+    cd FuelLib/source
     python Export4Pele.py --fuel_name heptane-decane
 
 
-This generates the following input file, ``FuelLib/sprayPropsGCM/sprayPropsGCM_heptane-decane.inp``, for use in a PeleLMeX simulation: ::
+This generates the following input file, ``FuelLib/exportData/sprayPropsGCM_heptane-decane.inp``, for use in a PeleLMeX simulation: ::
+
+    # -----------------------------------------------------------------------------
+    # sprayPropsGCM_heptane-decane.inp
+    # Generated on <YYY-MM-DD> <HH-MM-SS>
+    # FuelLib remote URL: https://github.com/NREL/FuelLib.git
+    # Git commit: <commit-hash>
+    # Units: MKS
+    # -----------------------------------------------------------------------------
 
     particles.spray_fuel_num = 2
     particles.fuel_species = NC7H16 NC10H22
@@ -165,7 +174,7 @@ This generates the following input file, ``FuelLib/sprayPropsGCM/sprayPropsGCM_h
     particles.NC10H22_cp = 1630.488028169014 3098.1056338028166 -1024.456338028169 # J/kg/K
     particles.NC10H22_latent = 368035.211268 # J/kg
 
-To include these parameters in your Pele simulation, copy the ``sprayPropsGCM.inp`` 
+To include these parameters in your Pele simulation, copy the ``sprayPropsGCM_heptane-decane.inp`` 
 file to the specific case directory and include the following line in your Pele input file: ::
 
     FILE = sprayPropsGCM.inp
@@ -177,6 +186,7 @@ namely the name of the fuel. This is designed for conventional jet fuels such as
 67 liquid fuel species corresponding to the GCxGC data, but only a single 
 gas-phase mechanism species, "POSF10325". For example: ::
 
+    cd FuelLib/source
     python Export4Pele.py --fuel_name posf10325
 
 will result in the following: ::
@@ -197,10 +207,11 @@ There are four additional options that can be specified when running the export 
 - ``--units``: Specify the units for the properties. The default is "mks" but users can set the units to "cgs" for use in PeleC.
 - ``--dep_fuel_names``: Specify which gas-phase species the liquid fuel deposits. The default is the same as the fuel name, but users can specify a single gas-phase species or a list of gas-phase species.
 - ``--max_dep_fuels``: Specify the maximum number of dependent fuels. The default is 30 and is a bit arbitrary.
-- ``--export_dir``: Specify the directory to export the file. The default is "FuelLib/sprayPropsGCM".
+- ``--export_dir``: Specify the directory to export the file. The default is "FuelLib/exportData".
 
 To specify all liquid fuel species deposity to a single gas-phase species, run the following command: ::
 
+    cd FuelLib/source
     python Export4Pele.py --fuel_name heptane-decane --dep_fuel_names SINGLE_GAS
 
 This will result in the following: ::
@@ -233,6 +244,7 @@ If there are more than 30 components and the user wants each component to deposi
 to a gas-phase species of the same name, the user can increase ``--max_dep_fuels`` 
 to a value greater than 30, however this would be required a massive mechanism for Pele and is not advised ::
 
+    cd FuelLib/source
     python Export4Pele.py --fuel_name posf10325 --max_dep_fuels 67
 
 
@@ -262,10 +274,11 @@ Default Options
     
 From the ``FuelLib`` directory, run the following command in the terminal, noting that ``--fuel_name`` is the only required input: ::
     
+    cd FuelLib/source
     python Export4Converge.py --fuel_name posf10325
 
 
-This generates the file ``FuelLib/mixturePropsGCM/mixturePropsGCM_posf10325.csv`` with mixture 
+This generates the file ``FuelLib/exportData/mixturePropsGCM_posf10325.csv`` with mixture 
 property predictions from 0 K to 1000 K for use in a Converge simulation.
 
 Additional Options
@@ -277,7 +290,7 @@ There are four additional options that can be specified when running the export 
 - ``--temp_min``: Specify the minimum temperature. The default is 0 K.
 - ``--temp_max``: Specify the maximum temperature. The default is 1000 K.
 - ``--temp_step``: Specify the temperature step size. The default is :math:`\Delta T = 10` K.
-- ``--export_dir``: Specify the directory to export the file. The default is "FuelLib/mixturePropsGCM".
+- ``--export_dir``: Specify the directory to export the file. The default is "FuelLib/exportData".
   
 .. note::
     The mixture property predictions may not be valid from the specified ``temp_min`` to ``temp_max``, 

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+FUELLIB_DIR = os.path.dirname(__file__)
+GCMTABLE_DIR = os.path.join(FUELLIB_DIR, "gcmTableData")
+SOURCE_DIR = os.path.join(FUELLIB_DIR, "source")
+FUELDATA_DIR = os.path.join(FUELLIB_DIR, "fuelData")
+FUELDATA_GC_DIR = os.path.join(FUELDATA_DIR, "gcData")
+FUELDATA_DECOMP_DIR = os.path.join(FUELDATA_DIR, "groupDecompositionData")
+FUELDATA_PROPS_DIR = os.path.join(FUELDATA_DIR, "propertiesData")
+TESTS_DIR = os.path.join(FUELLIB_DIR, "tests")
+TESTS_BASELINE_DIR = os.path.join(TESTS_DIR, "baselinePredictions")
+TUTORIALS_DIR = os.path.join(FUELLIB_DIR, "tutorials")
+
+sys.path.append(SOURCE_DIR)

--- a/source/Export4Converge.py
+++ b/source/Export4Converge.py
@@ -1,8 +1,15 @@
-import pandas as pd
-import numpy as np
 import os
+import sys
+import numpy as np
+import pandas as pd
 import argparse
 import FuelLib as fl
+
+# Add the FuelLib directory to the Python path
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+if FUELLIB_DIR not in sys.path:
+    sys.path.append(FUELLIB_DIR)
+from paths import *
 
 """
 Script that exports mixture properties over large temperature range for use in
@@ -24,9 +31,7 @@ Options:
 """
 
 
-def export_converge(
-    fuel, path="mixturePropsGCM", units="mks", temp_min=0, temp_max=1000, temp_step=10
-):
+def export_converge(fuel, path, units, temp_min, temp_max, temp_step):
     """
     Export mixture fuel properties to .csv for Converge simulations.
 
@@ -34,19 +39,19 @@ def export_converge(
     :type fuel: groupContribution object
 
     :param path: Directory to save the input file.
-    :type path: str, optional
+    :type path: str
 
     :param units: Units for the properties ("mks" for SI, "cgs" for CGS).
-    :type units: str, optional
+    :type units: str
 
     :param temp_min: Minimum temperature (K) for the property calculations.
-    :type temp_min: float, optional
+    :type temp_min: float
 
     :param temp_max: Maximum temperature (K)for the property calculations.
-    :type temp_max: float, optional
+    :type temp_max: float
 
     :param temp_step: Step size for temperature (K).
-    :type temp_step: float, optional
+    :type temp_step: float
 
     :return: None
     :rtype: None
@@ -247,7 +252,7 @@ def main():
     :param --temp_step: Step size for temperature (K) (optional, default: 10).
     :type --temp_step: float, optional
 
-    :param --export_dir: Directory to export the properties. Default is "sprayPropsGCM".
+    :param --export_dir: Directory to export the properties. Default is "FuelLib/exportData".
     :type --export_dir: str, optional
 
     :raises FileNotFoundError: If required files for the specified fuel are not found.
@@ -300,8 +305,8 @@ def main():
     # Optional argument for export directory
     parser.add_argument(
         "--export_dir",
-        default="mixturePropsGCM",
-        help="Directory to export the properties (optional, default: mixturePropsGCM).",
+        default=os.path.join(FUELLIB_DIR, "exportData"),
+        help="Directory to export the properties (optional, default: FuelLib/exportData).",
     )
 
     # Parse arguments
@@ -324,33 +329,23 @@ def main():
 
     # Check if necessary files exist in the fuelData directory
     print("\nChecking for required files...")
-    decomp_dir = os.path.join(
-        fl.groupContribution.fuelDataDir, "groupDecompositionData"
-    )
-    gcxgc_dir = os.path.join(fl.groupContribution.fuelDataDir, "gcData")
-    gcxgc_file = os.path.join(gcxgc_dir, f"{fuel_name}_init.csv")
-    decomp_file = os.path.join(decomp_dir, f"{fuel_name}.csv")
+    gcxgc_file = os.path.join(FUELDATA_GC_DIR, f"{fuel_name}_init.csv")
+    decomp_file = os.path.join(FUELDATA_DECOMP_DIR, f"{fuel_name}.csv")
     if not os.path.exists(gcxgc_file):
         raise FileNotFoundError(
-            f"GCXGC file for {fuel_name} not found in {gcxgc_dir}. gxcgc_file = {gcxgc_file}"
+            f"GCXGC file for {fuel_name} not found in {FUELDATA_GC_DIR}. gxcgc_file = {gcxgc_file}"
         )
     if not os.path.exists(decomp_file):
         raise FileNotFoundError(
-            f"Decomposition file for {fuel_name} not found in {decomp_dir}."
+            f"Decomposition file for {fuel_name} not found in {FUELDATA_DECOMP_DIR}."
         )
     print("All required files found.")
 
     # Create the groupContribution object for the specified fuel
-    fuel = fl.groupContribution(fuel_name)
+    fuel = fl.fuel(fuel_name)
 
     # Export properties for Pele
-    export_converge(
-        fuel,
-        path=export_dir,
-        units=units,
-        temp_min=temp_min,
-        temp_max=temp_max,
-    )
+    export_converge(fuel, export_dir, units, temp_min, temp_max, temp_step)
 
     print("\nExport completed successfully!")
 

--- a/source/FuelLib.py
+++ b/source/FuelLib.py
@@ -1,10 +1,17 @@
-import pandas as pd
-import numpy as np
-from scipy.optimize import curve_fit
 import os
+import sys
+import numpy as np
+import pandas as pd
+from scipy.optimize import curve_fit
+
+# Add the FuelLib directory to the Python path
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+if FUELLIB_DIR not in sys.path:
+    sys.path.append(FUELLIB_DIR)
+from paths import *
 
 
-class groupContribution:
+class fuel:
     """
     Class for handling group contribution calculations of thermodynamic and mixture properties.
 
@@ -16,16 +23,6 @@ class groupContribution:
     :type W: int
     """
 
-    # Paths to input directories
-    fuellibDir = os.path.dirname(os.path.abspath(__file__))
-    gcmTableDir = os.path.join(fuellibDir, "gcmTableData")
-    fuelDataDir = os.path.join(fuellibDir, "fuelData")
-    groupDecompDir = os.path.join(fuelDataDir, "groupDecompositionData")
-    gcxgcDir = os.path.join(fuelDataDir, "gcData")
-
-    # Path to GCM table
-    gcmTableFile = os.path.join(gcmTableDir, "gcmTable.csv")
-
     # Number of first and second order groups from Constantinou and Gani
     N_g1 = 78
     N_g2 = 43
@@ -33,15 +30,16 @@ class groupContribution:
     # Boltzmann's constant J/K
     k_B = 1.380649e-23
 
-    def __init__(self, name, decompName=None, W=1):
+    def __init__(self, name, decompName=None):
         # Initializes the composition and calculates the GCM properties for the
         # specified mixture.
 
         self.name = name
         if decompName is None:
             decompName = name
-        groupDecompFile = os.path.join(self.groupDecompDir, f"{decompName}.csv")
-        gcxgcFile = os.path.join(self.gcxgcDir, f"{name}_init.csv")
+        groupDecompFile = os.path.join(FUELDATA_DECOMP_DIR, f"{decompName}.csv")
+        gcxgcFile = os.path.join(FUELDATA_GC_DIR, f"{name}_init.csv")
+        gcmTableFile = os.path.join(GCMTABLE_DIR, "gcmTable.csv")
 
         # Read functional group data for mixture (num_compounds,num_groups)
         df_Nij = pd.read_csv(groupDecompFile)
@@ -93,32 +91,30 @@ class groupContribution:
             )
 
         # Read and store GCM table properties
-        df_gcm_properties = pd.read_csv(self.gcmTableFile)
-        gcm_properties = df_gcm_properties.loc[
-            :, ~df_gcm_properties.columns.isin(["Property", "Units"])
-        ].to_numpy()
+        df_table = pd.read_csv(gcmTableFile)
+        df_table = df_table.drop(columns=["Units"])
 
-        # Determine if approximations include second-order contributions
-        if W == 0 or self.num_groups < self.N_g1 + self.N_g2:
-            # Only retain first-order GCM properties
-            gcm_properties = gcm_properties[:, 0 : self.N_g1]
-            self.Nij = self.Nij[:, 0 : self.N_g1]
+        def get_row(property_name):
+            row = df_table[df_table["Property"] == property_name]
+            if row.empty:
+                raise ValueError(f"Property '{property_name}' not found in GCM table.")
+            return row.iloc[:, 1:].to_numpy().flatten()
 
         # Table data for functional groups (num_compounds,)
-        Tck = gcm_properties[0]  # critical temperature (1)
-        Pck = gcm_properties[1]  # critical pressure (bar)
-        Vck = gcm_properties[2]  # critical volume (m^3/kmol)
-        Tbk = gcm_properties[3]  # boiling temperature (1)
-        Tmk = gcm_properties[4]  # melting point temperature (1)
-        hfk = gcm_properties[5]  # enthalpy of formation, (kJ/mol)
-        gfk = gcm_properties[6]  # Gibbs energy (kJ/mol)
-        hvk = gcm_properties[7]  # latent heat of vaporization (kJ/mol)
-        wk = gcm_properties[8]  # accentric factor (1)
-        Vmk = gcm_properties[9]  # liquid molar volume fraction (m^3/kmol)
-        cpak = gcm_properties[10]  # specific heat values (J/mol/K)
-        cpbk = gcm_properties[11]  # specific heat values (J/mol/K)
-        cpck = gcm_properties[12]  # specific heat values (J/mol/K)
-        mwk = gcm_properties[13]  # molecular weights (g/mol)
+        Tck = get_row("tck")  # critical temperature (1)
+        Pck = get_row("pck")  # critical pressure (bar)
+        Vck = get_row("vck")  # critical volume (m^3/kmol)
+        Tbk = get_row("tbk")  # boiling temperature (1)
+        Tmk = get_row("tmk")  # melting point temperature (1)
+        hfk = get_row("hfk")  # enthalpy of formation, (kJ/mol)
+        gfk = get_row("gfk")  # Gibbs energy (kJ/mol)
+        hvk = get_row("hvk")  # latent heat of vaporization (kJ/mol)
+        wk = get_row("wk")  # accentric factor (1)
+        Vmk = get_row("vmk")  # liquid molar volume fraction (m^3/kmol)
+        cpak = get_row("CpAk")  # specific heat values (J/mol/K)
+        cpbk = get_row("CpBk")  # specific heat values (J/mol/K)
+        cpck = get_row("CpCk")  # specific heat values (J/mol/K)
+        mwk = get_row("MW")  # molecular weights (g/mol)
 
         # --- Compute critical properties at standard temp (num_compounds,)
         # Molecular weights

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,8 +1,16 @@
 import os
+import sys
 import numpy as np
 import pandas as pd
 import test_functions as fxns
 import unittest
+
+# Add the FuelLib directory to the Python path
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+if FUELLIB_DIR not in sys.path:
+    sys.path.append(FUELLIB_DIR)
+from paths import *
+import FuelLib as fl
 
 
 class CompTestCase(unittest.TestCase):
@@ -10,8 +18,6 @@ class CompTestCase(unittest.TestCase):
 
     def test_accuracy(self):
         """Does the PR impact the accuracy of single component fuel predictions?"""
-        test_dir = os.path.dirname(__file__)
-        baseline_dir = os.path.join(test_dir, "baselinePredictions")
 
         # Set the percentage for variation in max error
         max_error_diff = 1e-6
@@ -38,7 +44,7 @@ class CompTestCase(unittest.TestCase):
         # Compare to NIST predictions and previous model predictions
         for fuel_name in fuel_names:
 
-            baseline_file = os.path.join(baseline_dir, f"{fuel_name}.csv")
+            baseline_file = os.path.join(TESTS_BASELINE_DIR, f"{fuel_name}.csv")
             df_base = pd.read_csv(baseline_file, skiprows=[1])
 
             for prop in prop_names:

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,17 +1,20 @@
+import os
+import sys
 import numpy as np
 import pandas as pd
-import os
 import test_functions as fxns
 
 """
 Script for calculating baseline FuelLib mixture property predictions for CI testing
 Use this to update threshold values in CI test as model improves
 """
-import sys
+
 
 # Add the FuelLib directory to the Python path
-fuellib_dir = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(fuellib_dir)
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+if FUELLIB_DIR not in sys.path:
+    sys.path.append(FUELLIB_DIR)
+from paths import *
 import FuelLib as fl
 
 # Directories for tests and baseline predictions

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,21 +1,22 @@
 import os
+import sys
 import numpy as np
 import pandas as pd
-import sys
 
 # Add the FuelLib directory to the Python path
-fuellib_dir = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(fuellib_dir)
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+if FUELLIB_DIR not in sys.path:
+    sys.path.append(FUELLIB_DIR)
+from paths import *
 import FuelLib as fl
 
 
 def getPredAndData(fuel_name, prop_name):
     # Get the fuel properties based on the GCM
-    fuel = fl.groupContribution(fuel_name)
+    fuel = fl.fuel(fuel_name)
 
     data_file = f"{fuel_name}.csv"
-    dataPath = os.path.join(fuel.fuelDataDir, "propertiesData")
-    data = pd.read_csv(os.path.join(dataPath, data_file), skiprows=[1])
+    data = pd.read_csv(os.path.join(FUELDATA_PROPS_DIR, data_file), skiprows=[1])
 
     # Separate properties and associated temperatures from data
     T_data = data.Temperature[data[prop_name].notna()].to_numpy(dtype=float)

--- a/tutorials/basic.py
+++ b/tutorials/basic.py
@@ -1,14 +1,14 @@
 import os
 import sys
-import numpy as np
 
 # Add the FuelLib directory to the Python path
-fuellib_dir = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(fuellib_dir)
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(FUELLIB_DIR)
+import paths
 import FuelLib as fl
 
-# Create a groupContribution object for the fuel "heptane-decane"
-fuel = fl.groupContribution("heptane-decane")
+# Create a fuel object for the fuel "heptane-decane"
+fuel = fl.fuel("heptane-decane")
 
 # Display fuel name, components, initial composition, and critical temperature
 print(f"Fuel name: {fuel.name}")

--- a/tutorials/compositionPlots.py
+++ b/tutorials/compositionPlots.py
@@ -1,18 +1,19 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import pandas as pd
 import os
-import re
 import sys
+import numpy as np
+import pandas as pd
+import re
+import matplotlib.pyplot as plt
 
 # Add the FuelLib directory to the Python path
-fuellib_dir = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(fuellib_dir)
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(FUELLIB_DIR)
+import paths
 import FuelLib as fl
 
 fuel_name = "posf10325"
 
-fuel = fl.groupContribution(fuel_name)
+fuel = fl.fuel(fuel_name)
 
 # Classify compounds into families
 aromatic = [

--- a/tutorials/hefaBlends.py
+++ b/tutorials/hefaBlends.py
@@ -1,12 +1,13 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import pandas as pd
 import os
 import sys
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
 
 # Add the FuelLib directory to the Python path
-fuellib_dir = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(fuellib_dir)
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(FUELLIB_DIR)
+from paths import *
 import FuelLib as fl
 
 # -----------------------------------------------------------------------------
@@ -60,12 +61,11 @@ def getPredAndData(fuel_name, prop_name, blend):
     blend = np.array(blend) * 1e-2  # Convert to weight percent
 
     # Get the fuel properties based on the GCM
-    fuel = fl.groupContribution(fuel_name, "hefa")
-    jetA = fl.groupContribution(conv_fuel_name)
+    fuel = fl.fuel(fuel_name, "hefa")
+    jetA = fl.fuel(conv_fuel_name)
 
     data_file = "hefa-jet-a-blends.csv"
-    dataPath = os.path.join(fuel.fuelDataDir, "propertiesData")
-    data = pd.read_csv(os.path.join(dataPath, data_file), skiprows=[1])
+    data = pd.read_csv(os.path.join(FUELDATA_PROPS_DIR, data_file), skiprows=[1])
     col = f"{prop_name}_{fuel_name[5:].upper()}"
     prop_data = data[col]
     blend_data = data["HEFA_concentration"]

--- a/tutorials/mixtureProperties.py
+++ b/tutorials/mixtureProperties.py
@@ -1,12 +1,13 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import pandas as pd
 import os
 import sys
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
 
 # Add the FuelLib directory to the Python path
-fuellib_dir = os.path.dirname(os.path.dirname(__file__))
-sys.path.append(fuellib_dir)
+FUELLIB_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(FUELLIB_DIR)
+from paths import *
 import FuelLib as fl
 
 # -----------------------------------------------------------------------------
@@ -84,11 +85,10 @@ ylab = {
 
 def getPredAndData(fuel_name, prop_name):
     # Get the fuel properties based on the GCM
-    fuel = fl.groupContribution(fuel_name)
+    fuel = fl.fuel(fuel_name)
 
     data_file = f"{fuel_name}.csv"
-    dataPath = os.path.join(fuel.fuelDataDir, "propertiesData")
-    data = pd.read_csv(os.path.join(dataPath, data_file), skiprows=[1])
+    data = pd.read_csv(os.path.join(FUELDATA_PROPS_DIR, data_file), skiprows=[1])
 
     # Separate properties and associated temperatures from data
     T_data = data.Temperature[data[prop_name].notna()]


### PR DESCRIPTION
This includes some breaking changes and reorganization of files (last time I promise).

**Breaking changes**:
- Creation of a `source` directory. This is necessary for organization as we build toward including multi-component evaporation models within FuelLib.
- In `FuelLib.py`, the `groupContribution` class was renamed `fuel`. This was motivated by the fact that the class is much more than GCM. It provides a characterization of the fuel. All instances of `groupContribution` must now be called using the following:
     ~~~
    import FuelLib as fl
     # Old instance
    fuel = fl.groupContribution(<fuel_name>)
    # New instance
    fuel = fl.fuel(<fuel_name>)
    ~~~
   This does also makes the documentation more clear.

**Path Management**
- There is now a file `FuelLib/paths.py` that creates variables for the various paths. Any file that imports `paths` automatically imports the `source` directory.