### PR TITLE
Only add existing families to composition bar plots

### DIFF
--- a/tutorials/compositionPlots.py
+++ b/tutorials/compositionPlots.py
@@ -101,7 +101,11 @@ colors = {
 # Bar plot of the number of compounds in each family
 plt.figure(figsize=(7, 5))
 N = df.nC.unique()
+families_in_data = df["Family"].unique()
 for k, family in enumerate(family_names):
+    if family not in families_in_data:
+        # Only plot families that actually exist in the data
+        continue
     nC = df[df["Family"] == family].nC
     weight = df[df["Family"] == family]["Weight %"]
 


### PR DESCRIPTION
This PR improves the robustness of the plotting code in `compositionPlots.py` by ensuring that only families present in the dataset are plotted. This prevents errors or empty plots when some expected families are missing from the data.